### PR TITLE
Add simple RequestFilter so clients can implement auth

### DIFF
--- a/gomusicbrainz.go
+++ b/gomusicbrainz.go
@@ -104,6 +104,7 @@ func NewWS2Client(wsurl, appname, version, contact string) (*WS2Client, error) {
 // WS2Client defines a Go client for the MusicBrainz Web Service 2.
 type WS2Client struct {
 	WS2RootURL      *url.URL // The API root URL
+	RequestFilter   func(*http.Request)
 	userAgentHeader string
 }
 
@@ -140,6 +141,10 @@ func (c *WS2Client) getRequest(data interface{}, params url.Values, endpoint str
 	}
 
 	req.Header.Set("User-Agent", c.userAgentHeader)
+
+	if c.RequestFilter != nil {
+		c.RequestFilter(req)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
This is so clients can implement Basic or Digest auth. The spec mentions digest auth, but the server I'm using also supports basic auth.

So, you can do something like this:

```
client.RequestFilter = func(req *http.Request) {
    req.SetBasicAuth("username", "password")
}
```

However, I'm aware this is a hack... if you have any suggestions as to a better way to do this, I'd be happy to do that instead.