### PR TITLE
Check for empty date

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -90,16 +90,18 @@ func (t *BrainzTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	var err error
 	d.DecodeElement(&v, &start)
 
-	switch strings.Count(v, "-") {
-	case 0:
-		t.Time, err = time.Parse("2006", v)
-		t.Accuracy = Year
-	case 1:
-		t.Time, err = time.Parse("2006-01", v)
-		t.Accuracy = Month
-	case 2:
-		t.Time, err = time.Parse("2006-01-02", v)
-		t.Accuracy = Day
+	if v != "" {
+		switch strings.Count(v, "-") {
+		case 0:
+			t.Time, err = time.Parse("2006", v)
+			t.Accuracy = Year
+		case 1:
+			t.Time, err = time.Parse("2006-01", v)
+			t.Accuracy = Month
+		case 2:
+			t.Time, err = time.Parse("2006-01-02", v)
+			t.Accuracy = Day
+		}
 	}
 
 	return err


### PR DESCRIPTION
Some recordings don't have a date, so Go crashes when comparing `""` to `"2006"`. This is a small workaround to prevent that and allow the program to fallback to Go's default value.